### PR TITLE
Use Playwright for Genkit UI interaction in genkit-plugin-port skill

### DIFF
--- a/.codex/skills/genkit-plugin-port/SKILL.md
+++ b/.codex/skills/genkit-plugin-port/SKILL.md
@@ -11,7 +11,7 @@ You are a software engineer tasked with porting a Genkit plugin from a source la
 
 You have access to:
 
-- A web browser tool **"agent-browser"** (https://agent-browser.dev/) used for interacting with the Genkit UI (and for researching language/library equivalents and Genkit plugin APIs when needed).
+- A browser automation tool via `mcp__browser_tools__run_playwright_script` (Playwright) for interacting with the Genkit UI (and for researching language/library equivalents and Genkit plugin APIs when needed).
 - The plugin's repository, including source code, tests, and any example/test app.
 - A filesystem and CLI to inspect, build, run, and test the code.
 
@@ -47,7 +47,7 @@ Produce a complete port that includes:
 4) Validate equivalence:
    - Run the original tests (where possible) to understand expected behavior
    - Run the translated tests and example app
-   - Use **"agent-browser"** to interact with the Genkit UI and verify the translated plugin behaves the same (configuration, flows/tools visibility, execution traces, streaming, errors).
+  - Use Playwright via `mcp__browser_tools__run_playwright_script` to interact with the Genkit UI and verify the translated plugin behaves the same (configuration, flows/tools visibility, execution traces, streaming, errors).
 
 ## Constraints
 


### PR DESCRIPTION
### Motivation
- Replace the unavailable `agent-browser` reference with the environment-appropriate Playwright tool `mcp__browser_tools__run_playwright_script` so UI interaction guidance matches available automation tooling.

### Description
- Updated `.codex/skills/genkit-plugin-port/SKILL.md` to replace mentions of `agent-browser` with `mcp__browser_tools__run_playwright_script` and to instruct using Playwright for Genkit UI parity checks.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8383bcb5c832784f6fe87a1c80ee1)