### PR TITLE
Add Genkit Dart quality loop skill

### DIFF
--- a/.codex/skills/genkit-dart-quality-loop/SKILL.md
+++ b/.codex/skills/genkit-dart-quality-loop/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: genkit-dart-quality-loop
+description: Run the standard Genkit Dart quality gate loop. Use when working on Genkit repositories or plugins to repeatedly execute formatting, analysis, code generation, and tests until all checks pass with no issues.
+---
+
+# Genkit Dart Quality Loop
+
+Execute this exact command sequence from the repository root:
+
+1. `dart format .`
+2. `melos run analyze`
+3. `melos run build-gen`
+4. `melos run test`
+
+After running all four commands, evaluate the results.
+
+- If any command reports issues or fails, fix the issues and run the full four-command sequence again from the top.
+- Continue iterating until all four commands complete with no issues.
+
+## Execution rules
+
+- Always run from the repo root.
+- Do not skip steps, even if only one command failed in the previous iteration.
+- Prefer minimal fixes that preserve existing behavior.
+- Before finalizing work, ensure the last full iteration has all four commands passing.


### PR DESCRIPTION
### Motivation

- Provide a reusable Codex skill that documents and enforces the standard Genkit Dart quality loop (format, analysis, codegen, and tests) so contributors run an iterative quality gate until all checks pass.

### Description

- Add `.codex/skills/genkit-dart-quality-loop/SKILL.md` with YAML frontmatter and instructions to run `dart format .`, `melos run analyze`, `melos run build-gen`, and `melos run test` from the repo root, plus iteration and execution rules requiring the full sequence be re-run until all commands pass.

### Testing

- No runtime/build tests were run; file contents and repository operations were validated by running `nl -ba .codex/skills/genkit-dart-quality-loop/SKILL.md`, `git status --short`, `git add .codex/skills/genkit-dart-quality-loop/SKILL.md`, and `git commit -m "Add Genkit Dart quality loop skill"`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a835b804bc8327a411534b3932fe5d)