### PR TITLE
Add capability-focused test apps requirement and expand Genkit plugin port SKILL.md

### DIFF
--- a/.codex/skills/genkit-plugin-port/SKILL.md
+++ b/.codex/skills/genkit-plugin-port/SKILL.md
@@ -34,6 +34,7 @@ Produce a complete port that includes:
 2) Any accompanying test/example app translated (if present)  
 3) Updated build/config files for the target ecosystem  
 4) Documentation updates (README / usage snippets) reflecting the target language  
+5) Capability-focused test apps that validate major plugin features in an OpenAI-style format (for example: model resolution/listing, simple + streamed generation, and tool calling)
 
 ## Workflow
 
@@ -44,10 +45,32 @@ Produce a complete port that includes:
    - Main implementation
    - Integration points (Genkit registration, config, lifecycle)
    - Tests and example app
+   - Capability test apps that explicitly exercise each supported feature/capability in a clear, runnable, flow-per-scenario format
 4) Validate equivalence:
    - Run the original tests (where possible) to understand expected behavior
    - Run the translated tests and example app
+   - Run the capability test apps and verify each supported feature works end-to-end
+   - Execute each test-app flow directly (via CLI/dev UI) and confirm expected behavior for success paths, streaming paths, and tool-calling paths
    - Use **"agent-browser"** to interact with the Genkit UI and verify the translated plugin behaves the same (configuration, flows/tools visibility, execution traces, streaming, errors).
+
+## Capability Test Apps Requirement
+
+When porting a plugin, create test apps that mirror the structure/style of the provided OpenAI examples:
+
+- `model_resolution` scenario: resolve a model by name and list registered models
+- `simple_generation` scenario: basic generation plus streaming variant
+- `tool_calling` scenario: non-streaming and streaming tool/function-calling flows
+
+Use one focused file per scenario (or equivalent organization), include clear schema/type definitions, and wire each flow in `main` so it is immediately runnable for validation.
+
+If any capability requires real provider credentials, explicitly request the required API key(s) from the user before attempting live validation.
+
+Validation expectations for these test apps:
+
+- Run every flow at least once and capture concrete evidence (command/output snippet or trace) that it executed successfully.
+- For streaming flows, verify incremental chunks are emitted before final completion.
+- For tool-calling flows, verify the tool is invoked and its result influences the final model response.
+- For model resolution/listing flows, verify lookup succeeds for at least one known model and that list output is non-empty when models are available.
 
 ## Constraints
 
@@ -64,5 +87,7 @@ The port is complete when:
 
 - The plugin builds in the target language and passes its test suite.
 - The example/test app runs (if present).
+- Capability test apps exist for major features and are runnable.
+- Test-app flows have been executed and shown to work as expected (including streaming/tool-calling behavior where supported).
 - Behavior matches the original for documented use cases and edge cases, **including when exercised through the Genkit UI**.
 - Any unavoidable differences are explicitly documented.


### PR DESCRIPTION
### Motivation

- Clarify expectations for port completeness by requiring focused, runnable test apps that exercise major plugin features during a Genkit plugin port. 
- Provide concrete, actionable validation steps and success criteria for model resolution, generation (including streaming), and tool-calling flows so ports can be verified end-to-end. 

### Description

- Added a new Deliverable requiring capability-focused test apps as part of the port artifacts. 
- Expanded the Workflow to include creation and execution of dedicated capability test apps and explicit instructions to exercise each supported feature. 
- Introduced a `Capability Test Apps Requirement` section that specifies three scenarios (`model_resolution`, `simple_generation`, `tool_calling`) and mandates runnable, single-file flows with schema/type definitions. 
- Updated the Validation and Done Criteria to require executing the test-app flows, capturing evidence, and verifying streaming and tool-calling behavior. 

### Testing

- This change is documentation-only and does not modify runtime code, so no unit or integration tests needed to validate behavior changes. 
- Ran `markdownlint` and a documentation build/format check to validate the updated `SKILL.md`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a837e02b6c8327a09db7fe9f46f378)